### PR TITLE
POC of swapping graceful shutdown to SIGTERM

### DIFF
--- a/scripts/build_nginx
+++ b/scripts/build_nginx
@@ -41,6 +41,15 @@ echo "Downloading $zlib_url"
 echo "Downloading $uuid4_url"
 (cd nginx-${NGINX_VERSION} && curl -L $uuid4_url | tar xvz )
 
+echo "Graceful shutdown on term, terminate on bogus signal"
+SIGNAL_FILE="src/core/ngx_config.h"
+(
+ cd nginx-${NGINX_VERSION} \
+ && sed ${SIGNAL_FILE} -i -e "s/#define NGX_SHUTDOWN_SIGNAL.*/#define NGX_SHUTDOWN_SIGNAL      TERM/g" -e "s/#define NGX_TERMINATE_SIGNAL.*/#define NGX_TERMINATE_SIGNAL     CONT/g" \
+ && echo "Signals defined as" \
+ && grep "NGX.*SIGNAL" ${SIGNAL_FILE}
+)
+
 (
   cd nginx-${NGINX_VERSION}
   ./configure \


### PR DESCRIPTION
Swaps graceful shutdown behavior of nginx in our buildpack to SIGTERM.
Graceful shutdown becomes SIGTERM
Fast shutdown becomes SIGCONT, as a bogus signal

Testing:
Not done yet, 2 options:

1.
Create a test app on heroku
```
heroku create myapp
heroku add-buildpack -a myapp <blah>
heroku run bash -a myapp
```

2.
Run the binary the buildpack build outputs.

The artifact is an ELF
```
➜  bin git:(master) ✗ file nginx-cedar-14
nginx-cedar-14: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/l, for GNU/Linux 2.6.24, BuildID[sha1]=c49cdcd6beb3ff726a87683ad749f91acecb1737, with debug_info, not stripped
```
But not compatible w/ BSD/OSX :(
I _think_ we could start a docker container of cedar-14 and run the ELF from there, but probably easier to just make a dummy heroku app?
```
➜  bin git:(master) ✗ docker images | grep cedar
heroku/cedar                                   14                  ca0f5d00ade9        7 months ago        1.36GB
```

Notes:
I picked SIGCONT (continue stopped process) as the new signal for "fast shutdown", defined macros for signal resolution meant I couldn't just give a bogus/unused signal like `9000` without having a SIGNINETHOUSAND def.

I don't think this will cause issues, and felt better than having QUIT do something unexpected if Heroku ever starts sending QUIT.

I only did this for cedar-14, would want to make sure this is good for heroku 16/18 if we do this in the future

It took longer to write these notes than to make the actual POC, it's not great we'd have to potentially do something here as we upgrade stacks, but feel like right now a stack upgrade is probably non-trivial.

The output of the relevant part of the build is:
```
Graceful shutdown on term, terminate on bogus signal
Signals defined as
#define NGX_SHUTDOWN_SIGNAL      TERM
#define NGX_TERMINATE_SIGNAL     CONT
#define NGX_NOACCEPT_SIGNAL      WINCH
#define NGX_RECONFIGURE_SIGNAL   HUP
#define NGX_REOPEN_SIGNAL        INFO
#define NGX_CHANGEBIN_SIGNAL     XCPU
#define NGX_REOPEN_SIGNAL        USR1
#define NGX_CHANGEBIN_SIGNAL     USR2
```
